### PR TITLE
fix!: update to multiformats v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "docs": "aegir docs"
   },
   "dependencies": {
-    "@libp2p/interface-peer-id": "^1.0.4",
+    "@libp2p/interface-peer-id": "^2.0.0",
     "@libp2p/interface-registrar": "^2.0.3",
     "@libp2p/logger": "^2.0.1",
     "err-code": "^3.0.1",


### PR DESCRIPTION
The CID class in multiformats v11 has a breaking change so update all deps to use the new version